### PR TITLE
Use Nix to install dependencies in Publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,24 +20,16 @@ jobs:
       # ---------------------------------------------------------------------
       # Setup
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: "24.13.1"
-          registry-url: "https://registry.npmjs.org"
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-        with:
-          version: "10.27.0"
-
-      - run: pnpm install --frozen-lockfile
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      - run: nix run .#nix-develop .#workflow
+      - run: pnpm install
 
       # ---------------------------------------------------------------------
       # Build
 
       - run: ./node_modules/.bin/tsc
-      - run: npm --no-git-tag-version version from-git
 
       # ---------------------------------------------------------------------
       # Publish
 
-      - run: npm publish --access public
+      - run: pnpm publish --registry https://registry.npmjs.org --access public --no-git-checks


### PR DESCRIPTION
Using actions/setup-node and pnpm/action-setup requires us to manage the node/pnpm versions in two places. The setup-node action doesn't do much more than create a .npmrc with the registry URL. We can specify that URL in the `npm publish` command.